### PR TITLE
close capture session before closing media recorder

### DIFF
--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -693,6 +693,7 @@ public class CameraPlugin implements MethodCallHandler {
 
       try {
         recordingVideo = false;
+        closeCaptureSession();
         mediaRecorder.stop();
         mediaRecorder.reset();
         startPreview();


### PR DESCRIPTION
## Description
There was a problem with stopping recording on Android:
```
E/CameraDeviceGLThread-0(16837): Received exception on GL render thread:
E/CameraDeviceGLThread-0(16837): java.lang.IllegalStateException: swapBuffers: EGL error: 0x300d
E/CameraDeviceGLThread-0(16837): 	at android.hardware.camera2.legacy.SurfaceTextureRenderer.checkEglError(SurfaceTextureRenderer.java:530)
E/CameraDeviceGLThread-0(16837): 	at android.hardware.camera2.legacy.SurfaceTextureRenderer.swapBuffers(SurfaceTextureRenderer.java:523)
E/CameraDeviceGLThread-0(16837): 	at android.hardware.camera2.legacy.SurfaceTextureRenderer.drawIntoSurfaces(SurfaceTextureRenderer.java:727)
E/CameraDeviceGLThread-0(16837): 	at android.hardware.camera2.legacy.GLThreadManager$1.handleMessage(GLThreadManager.java:105)
E/CameraDeviceGLThread-0(16837): 	at android.os.Handler.dispatchMessage(Handler.java:98)
E/CameraDeviceGLThread-0(16837): 	at android.os.Looper.loop(Looper.java:148)
E/CameraDeviceGLThread-0(16837): 	at android.os.HandlerThread.run(HandlerThread.java:61)
I
```
Closing the capture session helped to prevent such crashing.

## Related Issues

flutter/flutter#23039
flutter/flutter#31414

## Breaking Change

This is *not* a breaking change.